### PR TITLE
Fix service account error

### DIFF
--- a/user/modules/service_accounts/service_accounts.tf
+++ b/user/modules/service_accounts/service_accounts.tf
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 resource "google_service_account" "sa" {
+  project      = "${var.project_id}"
   account_id   = "${var.namespace}-gmp-account"
   display_name = "Managed prometheus service account"
 }


### PR DESCRIPTION
There's an error where the project field is not properly set.  Minor fix that uses the project_id from variables.tf

Here's the error:

```
module.service_accounts.google_service_account.sa: Creating...
╷
│ Error: project: required field is not set
│ 
│   with module.service_accounts.google_service_account.sa,
│   on modules/service_accounts/service_accounts.tf line 15, in resource "google_service_account" "sa":
│   15: resource "google_service_account" "sa" {
```

After adding the fix:

```
module.service_accounts.google_service_account.sa: Creating...
module.service_accounts.google_service_account.sa: Creation complete after 1s 
```