### PR TITLE
Fix logging by passing provider metadata

### DIFF
--- a/platform/modules/gke_cluster/versions.tf
+++ b/platform/modules/gke_cluster/versions.tf
@@ -15,4 +15,7 @@
 terraform {
   required_providers {
   }
+  provider_meta "google" {
+    module_name = "blueprints/terraform/terraform-google-kubernetes-engine:kuberay/v0.1.0"
+  }
 }

--- a/platform/modules/kuberay/versions.tf
+++ b/platform/modules/kuberay/versions.tf
@@ -23,4 +23,7 @@ terraform {
       version = "2.18.1"
     }
   }
+  provider_meta "google" {
+    module_name = "blueprints/terraform/terraform-google-kubernetes-engine:kuberay/v0.1.0"
+  }
 }

--- a/platform/modules/kubernetes/versions.tf
+++ b/platform/modules/kubernetes/versions.tf
@@ -27,4 +27,7 @@ terraform {
       version = "2.0.1"
     }
   }
+  provider_meta "google" {
+    module_name = "blueprints/terraform/terraform-google-kubernetes-engine:kuberay/v0.1.0"
+  }
 }

--- a/user/modules/jupyterhub/versions.tf
+++ b/user/modules/jupyterhub/versions.tf
@@ -23,4 +23,7 @@ terraform {
       version = "2.18.1"
     }
   }
+  provider_meta "google" {
+    module_name = "blueprints/terraform/terraform-google-kubernetes-engine:kuberay/v0.1.0"
+  }
 }

--- a/user/modules/kuberay/versions.tf
+++ b/user/modules/kuberay/versions.tf
@@ -23,4 +23,7 @@ terraform {
       version = "2.18.1"
     }
   }
+  provider_meta "google" {
+    module_name = "blueprints/terraform/terraform-google-kubernetes-engine:kuberay/v0.1.0"
+  }
 }

--- a/user/modules/kubernetes/versions.tf
+++ b/user/modules/kubernetes/versions.tf
@@ -27,4 +27,7 @@ terraform {
       version = "2.0.1"
     }
   }
+  provider_meta "google" {
+    module_name = "blueprints/terraform/terraform-google-kubernetes-engine:kuberay/v0.1.0"
+  }
 }

--- a/user/modules/prometheus/versions.tf
+++ b/user/modules/prometheus/versions.tf
@@ -27,4 +27,7 @@ terraform {
       version = "2.0.1"
     }
   }
+  provider_meta "google" {
+    module_name = "blueprints/terraform/terraform-google-kubernetes-engine:kuberay/v0.1.0"
+  }
 }

--- a/user/modules/service_accounts/versions.tf
+++ b/user/modules/service_accounts/versions.tf
@@ -23,4 +23,7 @@ terraform {
       version = "2.18.1"
     }
   }
+  provider_meta "google" {
+    module_name = "blueprints/terraform/terraform-google-kubernetes-engine:kuberay/v0.1.0"
+  }
 }


### PR DESCRIPTION
The terraform-provider-google has a bug to pass provider metadata into submodels, so we need to manually pass them