### PR TITLE
Add ray job submission ID label to fluent bit logging

### DIFF
--- a/user/modules/kuberay/kuberay-values.yaml
+++ b/user/modules/kuberay/kuberay-values.yaml
@@ -127,8 +127,7 @@ head:
       volumeMounts:
       - mountPath: /tmp/ray
         name: ray-logs
-      - mountPath: /fluent-bit/etc/fluent-bit.conf
-        subPath: fluent-bit.conf
+      - mountPath: /fluent-bit/etc/
         name: fluentbit-config
 
 worker:
@@ -211,8 +210,7 @@ worker:
       volumeMounts:
       - mountPath: /tmp/ray
         name: ray-logs
-      - mountPath: /fluent-bit/etc/fluent-bit.conf
-        subPath: fluent-bit.conf
+      - mountPath: /fluent-bit/etc/
         name: fluentbit-config
 
 # The map's key is used as the groupName.

--- a/user/modules/kubernetes/config/fluentd_config.yaml
+++ b/user/modules/kubernetes/config/fluentd_config.yaml
@@ -18,12 +18,27 @@ metadata:
   name: fluentbit-config
 data:
   fluent-bit.conf: |
+    [SERVICE]
+        Parsers_File parsers.conf
     [INPUT]
         Name tail
         Path /tmp/ray/session_latest/logs/*
         Tag ray
-        Path_Key true
+        Path_Key filename
         Refresh_Interval 5
+    [FILTERS]
+        Name parser
+        Match ray
+        Key_Name filename
+        Parser rayjob
+        Reserve_Data On
     [OUTPUT]
         Name stdout
+        Format json_lines
         Match *
+
+  parsers.conf: |
+    [PARSER]
+        Name rayjob
+        Format regex
+        Regex (?<job_id>raysubmit_[^.]*)


### PR DESCRIPTION
Modify the fluent bit config to capture the ray job submission ID as a label that is searchable in cloud logging.

1) Add a parsers.conf file to the fluent bit config with a parser that captures the ray job ID from the log file name. The log file looks like "job-driver-raysubmit_rsrHRJzqpAKr9fCF.log" where "raysubmit_rsrHRJzqpAKr9fCF" is the ray job submission ID.
2) Output a structured JSON log to stdout with the job ID as one of the keys in that structure.
3) Change the volume mounts in the fluent bit sidecar to mount both files in the fluent bit config map (parsers.conf and fluent-bit.conf) so that fluent bit is able to load the parser.